### PR TITLE
Package augmatch, too

### DIFF
--- a/augeas.spec.in
+++ b/augeas.spec.in
@@ -99,6 +99,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %{_bindir}/augtool
 %{_bindir}/augparse
+%{_bindir}/augmatch
 %{_bindir}/fadot
 %doc %{_mandir}/man1/*
 %{_datadir}/vim/vimfiles/syntax/augeas.vim


### PR DESCRIPTION
Otherwise rpmbuild throws an error of 'Installed (but unpackaged) file(s) found'